### PR TITLE
Ensure compatibility with new hmac binary encoding.

### DIFF
--- a/src/main/java/com/jessecoyle/StoredSecret.java
+++ b/src/main/java/com/jessecoyle/StoredSecret.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 
+import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.Map;
 
@@ -21,19 +22,41 @@ class StoredSecret {
         return Base64.getDecoder().decode(value.getS());
     }
 
-    private static byte[] hexAttributeValueToBytes(AttributeValue value) {
+
+    private static byte[] decodeHex(char[] chars) {
         try {
-            return Hex.decodeHex(value.getS().toCharArray());
+            return Hex.decodeHex(chars);
         } catch (DecoderException e) {
             throw new RuntimeException(e);
         }
     }
 
+
+    private static byte[] hexAttributeValueToBytes(AttributeValue value) {
+        return decodeHex(value.getS().toCharArray());
+    }
+
+
+    private static byte[] binaryHexAttributeValueToBytes(AttributeValue value) {
+        ByteBuffer bb = value.getB();
+        byte[] bytes = new byte[bb.remaining()];
+        bb.get(bytes);
+        char[] chars = new String(bytes).toCharArray();
+        return decodeHex(chars);
+    }
+
+
     StoredSecret(Map<String, AttributeValue> item) {
         this.key = base64AttributeValueToBytes(item.get("key"));
         this.contents = base64AttributeValueToBytes(item.get("contents"));
-        this.hmac = hexAttributeValueToBytes(item.get("hmac"));
+        // fallback in case of hmac stored as an hex encoded binary value
+        if (item.get("hmac").getS() != null) {
+            this.hmac = hexAttributeValueToBytes(item.get("hmac"));
+        } else {
+            this.hmac = binaryHexAttributeValueToBytes(item.get("hmac"));
+        }
     }
+
 
     byte[] getKey() {
         return key;


### PR DESCRIPTION
From the version 1.13.1 of credstash, the hmac decoding causes a NullpointerException, because hmac is now stored as a hex encoded binary value in a different position.
This fix adds a fallback encoding in this case.

Similar to https://github.com/Narochno/Narochno.Credstash/pull/6/commits/647072c0bac5b3fd0f7c66e7e41b77e060533b88